### PR TITLE
Fix macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,10 @@ cargo test -p commandeer
 
 ```bash
 # Test record functionality
-cargo run -p commandeer-cli -- record --command echo "Hello, Commandeer!"
+cargo run -p commandeer-cli -- record --command echo "Hello, Commandeer"
 
 # Test replay functionality
-cargo run -p commandeer-cli -- replay --command echo "Hello, Commandeer!"
+cargo run -p commandeer-cli -- replay --command echo "Hello, Commandeer"
 ```
 
 ## Use Cases

--- a/commandeer-macros/src/lib.rs
+++ b/commandeer-macros/src/lib.rs
@@ -48,7 +48,7 @@ pub fn commandeer(args: TokenStream, input: TokenStream) -> TokenStream {
 
     // Create the setup statements
     let setup_stmts: Vec<syn::Stmt> = vec![parse_quote! {
-        let commandeer = crate::Commandeer::new(#test_file_name, crate::Mode::#mode_ident);
+        let commandeer = commandeer_test::Commandeer::new(#test_file_name, commandeer_test::Mode::#mode_ident);
     }];
 
     let mock_stmts: Vec<syn::Stmt> = mock_commands

--- a/commandeer-test/src/lib.rs
+++ b/commandeer-test/src/lib.rs
@@ -215,6 +215,7 @@ exec env PATH="{}" {} {} --file {} --command {command_name} "$@"
 
 #[cfg(test)]
 mod tests {
+    use crate as commandeer_test;
     use crate::{Commandeer, Mode, commandeer};
 
     #[serial_test::serial]


### PR DESCRIPTION
Use crate name path instead of crate when generating macro