### PR TITLE
- Implement drop on Commandeer to ensure PATH env variable is set to the original path.

### DIFF
--- a/commandeer-test/src/lib.rs
+++ b/commandeer-test/src/lib.rs
@@ -236,6 +236,14 @@ exec env PATH="{}" {} {} --file {} --command {command_name} "$@"
     }
 }
 
+impl Drop for Commandeer {
+    fn drop(&mut self) {
+        unsafe {
+            std::env::set_var("PATH", &self.original_path);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate as commandeer_test;


### PR DESCRIPTION
- Implement drop on Commandeer to ensure PATH env variable is set to the original path.